### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,11 +1,12 @@
 name: Playwright Tests
+permissions:
+    contents: read
 
 on:
     push:
         branches: [main]
     pull_request:
         branches: [main]
-
 jobs:
     test:
         timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/thomasglauser/gasschutzkorps.ch/security/code-scanning/1](https://github.com/thomasglauser/gasschutzkorps.ch/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimum required permissions. Since the workflow only needs to read repository contents (e.g., to check out the code), the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added at the top level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
